### PR TITLE
supported other principals in trust relationships

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -3,8 +3,9 @@
 ## Usage
 ### Create an IAM role to target aws account
 
-You can use this module like as below example. You can allow multiple accounts to assume the role adding them into `allowed_accounts` list. 
-#### latest example
+You can use this module like as below example. You can allow multiple accounts to assume the role adding them into `aws` in 'principals'. 
+
+#### The latest example
 
 ```
 module "infra-engineer-role" {
@@ -16,12 +17,12 @@ module "infra-engineer-role" {
   desc             = var.desc
   policy_arn       = ["arn:aws:iam::aws:policy/AdministratorAccess"]
   prinsipals       = {
-    "aws" = var.allowed_accounts
+    "aws" = ["111122223333", "222233334444"]
   }
 }
 ```
 
-#### Deprecated example
+#### Deprecated example (under 1.0.2)
 
 
 ```

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -4,6 +4,25 @@
 ### Create an IAM role to target aws account
 
 You can use this module like as below example. You can allow multiple accounts to assume the role adding them into `allowed_accounts` list. 
+#### latest example
+
+```
+module "infra-engineer-role" {
+  source  = "tf-mod/rbac-role/aws"
+  version = "1.0.0"
+
+  name             = var.name
+  stack            = var.stack
+  desc             = var.desc
+  policy_arn       = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  prinsipals       = {
+    "aws" = var.allowed_accounts
+  }
+}
+```
+
+#### Deprecated example
+
 
 ```
 module "infra-engineer-role" {

--- a/main.tf
+++ b/main.tf
@@ -8,13 +8,14 @@ resource "aws_iam_role" "role" {
 data "aws_iam_policy_document" "trustrel" {
   statement {
     effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = var.allowed_accounts
-    }
-
     actions = ["sts:AssumeRole"]
+    dynamic "principals" {
+      for_each = var.principals
+      content {
+        type        = lower(principals.key) == "aws" ? upper(principals.key) : title(principals.key)
+        identifiers = principals.value
+      }
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,12 @@
 # target roles
 
-variable "allowed_accounts" {
-  description = "The list of aws account ids to allow them to assume roles in this account(e.g. 857026751867)"
-  default = ["336686831133"] // This is the account number of ID account
+variable "principals" {
+  description = "The map of trust relationship to allow them to assume roles in this role"
+  default = {
+    aws = ["336686831133"]
+    service = [""]
+    federated = [""]
+  }
 }
 
 variable "policy_arn" {


### PR DESCRIPTION
I want to support other principals in trust relationships, so I made this PR
deprecated `allowed_accounts`
 - change to use `principals`
