### PR TITLE
Cherrypick session duration feature commit from 1.0.2

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -34,6 +34,7 @@ module "infra-engineer-role" {
   stack            = var.stack
   desc             = var.desc
   policy_arn       = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  session_duration = "7200"
   allowed_accounts = var.allowed_accounts
 }
 ```

--- a/examples/complete/rbac.tf
+++ b/examples/complete/rbac.tf
@@ -8,5 +8,6 @@ module "infra-engineer-role" {
   stack            = var.stack
   desc             = var.desc
   policy_arn       = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  session_duration = var.session_duration
   allowed_accounts = var.allowed_accounts
 }

--- a/examples/complete/terraform.tfvars
+++ b/examples/complete/terraform.tfvars
@@ -4,4 +4,5 @@ aws_profile      = "my"
 name             = "infrastructure-enginner"
 stack            = "dev"
 desc             = "extra-desc"
+session_duration = "7200"
 allowed_accounts = ["012345678912"]

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -22,6 +22,11 @@ variable "policy_arn" {
   default     = []
 }
 
+variable "session_duration" {
+  description = "A value for maximum time of session duration in seconds (default 1h). This setting can have a value from 1 hour to 12 hours"
+  default     = "3600"
+}
+
 # description
 variable "name" {
   description = "The logical name of role"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 
 # iam role module
 resource "aws_iam_role" "role" {
-  name               = local.name
-  assume_role_policy = data.aws_iam_policy_document.trustrel.json
+  name                 = local.name
+  assume_role_policy   = data.aws_iam_policy_document.trustrel.json
+  max_session_duration = var.session_duration
 }
 
 data "aws_iam_policy_document" "trustrel" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "policy_arn" {
   default     = []
 }
 
+variable "session_duration" {
+  description = "A value for maximum time of session duration in seconds (default 1h). This setting can have a value from 1 hour to 12 hours"
+  default     = "3600"
+}
+
 # description
 variable "name" {
   description = "The logical name of role"


### PR DESCRIPTION
I found out **Session duration** feature not merged into master.
So I cannot use this argument in v1.1.0

(feat) parameterisation of maximum sesssion duration (#3)