### PR TITLE
Add AssumeRoleWithWebIdentity to trust relationship

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,24 @@ resource "aws_iam_role" "role" {
 
 data "aws_iam_policy_document" "trustrel" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
     dynamic "principals" {
-      for_each = var.principals
+      for_each = { for k, v in var.principals : k => v if k == "aws" || k == "service" }
       content {
         type        = lower(principals.key) == "aws" ? upper(principals.key) : title(principals.key)
+        identifiers = principals.value
+      }
+    }
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    dynamic "principals" {
+      for_each = { for k, v in var.principals : k => v if k == "federated" }
+      content {
+        type        = lower(principals.key) == "federated" ? "Federated" : title(principals.key)
         identifiers = principals.value
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "trustrel" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     dynamic "principals" {
-      for_each = { for k, v in var.principals : k => v if k == "aws" || k == "service" }
+      for_each = { for k, v in var.principals : k => v if contains(["aws", "service"], k) }
       content {
         type        = lower(principals.key) == "aws" ? upper(principals.key) : title(principals.key)
         identifiers = principals.value
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "trustrel" {
     effect  = "Allow"
     actions = ["sts:AssumeRoleWithWebIdentity"]
     dynamic "principals" {
-      for_each = { for k, v in var.principals : k => v if k == "federated" }
+      for_each = { for k, v in var.principals : k => v if contains(["federated"], k) }
       content {
         type        = lower(principals.key) == "federated" ? "Federated" : title(principals.key)
         identifiers = principals.value

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
-
-output role_arn {
+output "role_arn" {
   value = aws_iam_role.role.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@
 variable "principals" {
   description = "The map of trust relationship to allow them to assume roles in this role"
   default = {
-    aws = ["336686831133"]
-    service = [""]
+    aws       = ["336686831133"]
+    service   = [""]
     federated = [""]
   }
 }


### PR DESCRIPTION
This module is supported only by the assume role. 
So, I added the AssumeRoleWithWebIdentity to the trust relationship in order to support federated.